### PR TITLE
refactor: rename Movie and MovieListResponse types for clarity

### DIFF
--- a/src/api/endpoints/movie.ts
+++ b/src/api/endpoints/movie.ts
@@ -1,5 +1,5 @@
 import { Effect } from 'effect'
-import { MovieListResponse } from '../types/movieResponses'
+import { TheaterMovie } from '../types/movieResponses'
 
 export class FetchError {
     readonly _tag = 'FetchError'
@@ -24,11 +24,11 @@ const fetchFromApi = (endpoint: string) => Effect.tryPromise({
 })
 
 const parseResponse = (response: Response) => Effect.tryPromise({
-    try: () => response.json() as Promise<MovieListResponse[]>,
+    try: () => response.json() as Promise<TheaterMovie[]>,
     catch: () => new FetchError('응답을 파싱하는데 실패했습니다')
 })
 
-const fetchMovies = (endpoint: string): Effect.Effect<MovieListResponse[], FetchError | NetworkError, never> =>
+const fetchMovies = (endpoint: string): Effect.Effect<TheaterMovie[], FetchError | NetworkError, never> =>
     Effect.gen(function* (_) {
         const response = yield* _(fetchFromApi(endpoint))
 

--- a/src/api/types/movieResponses.ts
+++ b/src/api/types/movieResponses.ts
@@ -1,4 +1,4 @@
-export interface MovieListResponse {
+export interface TheaterMovie {
     id: number
     title: string
     posterPath: string

--- a/src/mocks/streamingMovies.ts
+++ b/src/mocks/streamingMovies.ts
@@ -1,6 +1,6 @@
-import { Movie } from '../types/movie'
+import { StreamingMovie } from '../types/movie'
 
-const generateMockMovies = (page: number, itemsPerPage: number = 18): Movie[] => {
+const generateMockMovies = (page: number, itemsPerPage: number = 18): StreamingMovie[] => {
     const startIndex = (page - 1) * itemsPerPage
     return Array.from({ length: itemsPerPage }, (_, index) => ({
         id: startIndex + index + 1,

--- a/src/types/movie.ts
+++ b/src/types/movie.ts
@@ -1,4 +1,4 @@
-export interface Movie {
+export interface StreamingMovie {
     id: number
     title: string
     posterPath: string


### PR DESCRIPTION
- Rename Movie to StreamingMovie
- Rename MovieListResponse to TheaterMovie
- Update all related imports and usages

This change makes the purpose of each type more clear:
- StreamingMovie: for streaming service movies
- TheaterMovie: for theater movies (upcoming/now playing)