### PR TITLE
영화 포스터 기본 이미지 추가

### DIFF
--- a/public/default-poster.svg
+++ b/public/default-poster.svg
@@ -1,0 +1,9 @@
+<svg width="200" height="300" viewBox="0 0 200 300" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <!-- 어두운 배경 -->
+    <rect width="200" height="300" fill="#1a1a1a"/>
+    <!-- 영화 릴 아이콘 -->
+    <path d="M100 130c-11 0-20 9-20 20s9 20 20 20 20-9 20-20-9-20-20-20zm0 30c-5.5 0-10-4.5-10-10s4.5-10 10-10 10 4.5 10 10-4.5 10-10 10z" fill="#666"/>
+    <path d="M160 80H40c-11 0-20 9-20 20v100c0 11 9 20 20 20h120c11 0 20-9 20-20V100c0-11-9-20-20-20zm0 120H40V100h120v100z" fill="#666"/>
+    <!-- "No Poster" 텍스트 -->
+    <text x="100" y="200" font-family="Arial" font-size="16" fill="#999" text-anchor="middle">No Poster</text>
+</svg> 

--- a/src/api/endpoints/movie.ts
+++ b/src/api/endpoints/movie.ts
@@ -31,14 +31,18 @@ const parseResponse = <T>(response: Response) => Effect.tryPromise({
         if (Array.isArray(data)) {
             return data.map(item => ({
                 ...item,
-                posterPath: import.meta.env.VITE_POSTER_URL + item.posterPath
+                posterPath: item.posterPath
+                    ? import.meta.env.VITE_POSTER_URL + item.posterPath
+                    : '/default-poster.svg'
             })) as T
         }
 
         // 단일 영화 정보도 포스터 URL 처리
         return {
             ...data,
-            posterPath: import.meta.env.VITE_POSTER_URL + data.posterPath
+            posterPath: data.posterPath
+                ? import.meta.env.VITE_POSTER_URL + data.posterPath
+                : '/default-poster.svg'
         } as T
     },
     catch: () => new FetchError('응답을 파싱하는데 실패했습니다')

--- a/src/pages/Streaming/index.tsx
+++ b/src/pages/Streaming/index.tsx
@@ -64,7 +64,9 @@ function StreamingPage() {
                             <MovieList
                                 movies={data.movies.map(movie => ({
                                     ...movie,
-                                    posterPath: import.meta.env.VITE_POSTER_URL + movie.posterPath
+                                posterPath: movie.posterPath
+                                    ? import.meta.env.VITE_POSTER_URL + movie.posterPath
+                                    : '/default-poster.svg'
                             }))}
                             />
                         )

--- a/src/types/api/movie.ts
+++ b/src/types/api/movie.ts
@@ -1,7 +1,7 @@
 export interface StreamingMovie {
     id: number
     title: string
-    posterPath: string
+    posterPath?: string
 }
 
 export interface TheaterMovie {


### PR DESCRIPTION

## 변경사항
1. 기본 포스터 이미지 SVG 추가
   - 2:3 비율의 기본 포스터 이미지 생성
   - 어두운 배경과 영화 릴 아이콘, "No Poster" 텍스트 포함

2. API 응답 처리 시 포스터 null 처리 로직 통합
   - `movie.ts` API 엔드포인트에서 포스터 URL null 처리 로직 구현
   - 배열 및 단일 영화 정보 모두에 대해 일관된 처리 적용

## 코드 변경
````diff
// spooky-town/public/default-poster.svg
+ <svg width="200" height="300" viewBox="0 0 200 300" fill="none" xmlns="http://www.w3.org/2000/svg">
+     <!-- 어두운 배경 -->
+     <rect width="200" height="300" fill="#1a1a1a"/>
+     <!-- 영화 릴 아이콘 -->
+     <path d="M100 130c-11 0-20 9-20 20s9 20 20 20 20-9 20-20-9-20-20-20zm0 30c-5.5 0-10-4.5-10-10s4.5-10 10-10 10 4.5 10 10-4.5 10-10 10z" fill="#666"/>
+     <path d="M160 80H40c-11 0-20 9-20 20v100c0 11 9 20 20 20h120c11 0 20-9 20-20V100c0-11-9-20-20-20zm0 120H40V100h120v100z" fill="#666"/>
+     <!-- "No Poster" 텍스트 -->
+     <text x="100" y="200" font-family="Arial" font-size="16" fill="#999" text-anchor="middle">No Poster</text>
+ </svg>

// spooky-town/src/api/endpoints/movie.ts
const parseResponse = <T>(response: Response) => Effect.tryPromise({
    try: async () => {
        const data = await response.json()

        // 배열 데이터 처리
        if (Array.isArray(data)) {
            return data.map(item => ({
                ...item,
+               posterPath: item.posterPath
+                   ? import.meta.env.VITE_POSTER_URL + item.posterPath
+                   : '/default-poster.svg'
            })) as T
        }

        // 단일 영화 정보도 포스터 URL 처리
        return {
            ...data,
+           posterPath: data.posterPath
+               ? import.meta.env.VITE_POSTER_URL + data.posterPath
+               : '/default-poster.svg'
        } as T
    },
    catch: () => new FetchError('응답을 파싱하는데 실패했습니다')
})
````

## 테스트 필요 사항
1. 포스터가 없는 영화에서 기본 이미지 표시 확인
2. 스트리밍/상세 페이지 모두에서 정상 동작 확인
3. 기본 이미지 스타일이 기존 포스터와 동일하게 적용되는지 확인
